### PR TITLE
Adds DBClient to the API

### DIFF
--- a/api/lib/DBClient.js
+++ b/api/lib/DBClient.js
@@ -1,0 +1,21 @@
+const Cloudant = require('@cloudant/cloudant');
+
+const user = process.env.CLOUDANT_USER;
+const pw = process.env.CLOUDANT_PW;
+
+function DBClient() {
+    this._client = Cloudant({account:user, password:pw});
+}
+
+DBClient.prototype.insert = function(doc, db) {
+    return new Promise((res, rej) => {
+        let database = this._client.db.use(db);
+        database.insert(doc, (err, body, header) => {
+            if (err) return rej(err);
+            if (body.ok) return res(body);
+            else return rej(body);
+        });
+    });
+}
+
+module.exports = DBClient;


### PR DESCRIPTION
This is the second wrapper object we will have to contact our DB, this is intended so if we want to change DBs later on the project, we have a single file to change.
In this v1, only inserts are supported, and it uses Cloudant behind the scenes.

Sample usage:
```js
const DBClient = require('./api/lib/DBClient')
const dbInstance = new DBClient();

dbInstance.insert({'foo':'bar'}, 'menus')
    .then((resp) => console.log(resp));
```

Signed-off-by: Gabriel R. Sezefredo <gabriel@sezefredo.com.br>