### PR TITLE
Feature/create menu

### DIFF
--- a/api/lib/MulterConfig.js
+++ b/api/lib/MulterConfig.js
@@ -1,0 +1,31 @@
+const multer  = require('multer');
+const httpStatus = require('./http-status-codes');
+
+const configs = {
+    menus: {
+        fileFilter: (req, file, cb) => {
+            if (file.mimetype !== 'application/pdf'){
+                let err = new Error(`Wrong file type: "${file.mimetype}"`);
+                err.status = httpStatus.BAD_REQUEST;
+                return cb(err, false);
+            }
+            return cb(null, true);
+        },
+        limits: {
+            fileSize: 10485760, // 10MB
+            files: 1
+        }
+    }
+};
+
+function MulterConfig(type) {
+    if (configs[type])
+        return multer({
+            dest: 'uploads',
+            fileFilter: configs[type].fileFilter,
+            limits:  configs[type].limits
+        });
+    throw Error(`The specified multer config type doesn't exists: ${type}`)
+}
+
+module.exports = MulterConfig;

--- a/api/v1/menus/create.js
+++ b/api/v1/menus/create.js
@@ -1,4 +1,52 @@
-module.exports = (req, res) => {
-    // TODO: create menu method
-    return res.send('TODO: create menu method.');
+const FSClient = require('../../lib/FSClient');
+const DBClient = require('../../lib/DBClient');
+const fs = require('fs');
+
+const httpStatus = require('../../lib/http-status-codes');
+
+module.exports = (req, res, next) => {
+    let menuEntry = {
+        restaurant: {
+            name: req.body.restaurant_name,
+            address: req.body.restaurant_address,
+            city: req.body.restaurant_city
+        },
+        file: null,
+        ocr: []
+    }
+    // Check if request is missing parameters
+    for (let k in menuEntry.restaurant){
+        if (typeof menuEntry.restaurant[k] === 'undefined' || menuEntry.restaurant[k] === ''){
+            let err = new Error(`Missing field "restaurant_${k}"`);
+            err.status = httpStatus.BAD_REQUEST;
+            throw err;
+        }
+    }
+
+    // Uploading to box and saving to db
+    let fsClient = new FSClient();
+    let dbClient = new DBClient();
+    fsClient.uploadMenu(req.file)
+        .then(id => {
+            menuEntry.file = `/files/${id}`
+            return deleteFile(req.file.path);
+        })
+        .then(() => dbClient.insert(menuEntry, 'menus'))
+        .then(dbEntry => res.status(httpStatus.OK_CREATED).send(Object.assign(dbEntry, menuEntry)))
+        .catch((err) => {
+            return next(err) // Handled by the "menus" specific error handler, in menus/index.js
+        });
 };
+
+// "Promisifying" the fs.unlink function
+function deleteFile(path) {
+    return new Promise((res, rej) => {
+        fs.unlink(path, err => {
+            if (err) {
+                console.log(err.stack);
+                return rej(new Error('Error while trying to delete the temporary file'));
+            }
+            return res();
+        })
+    });
+}

--- a/api/v1/menus/index.js
+++ b/api/v1/menus/index.js
@@ -1,3 +1,7 @@
+// File upload configurations
+const MulterConfig = require('../../lib/MulterConfig');
+const upload = new MulterConfig('menus');
+
 const httpStatus = require('../../lib/http-status-codes');
 
 const menus = require('express').Router();
@@ -16,12 +20,22 @@ menus.get('/', (req, res) => {
     return getAll(req, res);
 });
 menus.get('/:id', getOne);
-menus.post('/', create);
+menus.post('/', upload.single('file'), create);
 menus.delete('/:id', del);
 menus.use('/:id/ocr', ocr);
 
 // Error Handler for menus
 menus.use(function (err, req, res, next) {
+    /*
+        This is not ideal, it's replacing the busboy error when a file is too large.
+        I couldn't find another way to send the error I wanted when this happened.
+        We should think about improving it later on.
+    */
+    if (err.code === 'LIMIT_FILE_SIZE') {
+        err.message += `, maximum file size: ${upload.limits.fileSize/1024/1024}MB`;
+        err.status = httpStatus.BAD_REQUEST;
+    }
+
     console.log(err.stack);
     res.status(err.status || httpStatus.INTERNAL_SERVER_ERROR).send(err.message);
 });


### PR DESCRIPTION
This commit implements the POST `menus` route.

You can test it by running (make sure the server is running at localhost:8080):

```js
var fs = require("fs");
var request = require("request");

var options = { 
    method: 'POST',
    url: 'http://localhost:8080/api/v1/menus',
    headers: { 'content-type': 'multipart/form-data' },
    formData: {
        file: {
            value: fs.createReadStream('/path/to/file.pdf'),
            options: {
                filename: '/path/to/file.pdf'
            }
        },
        restaurant_name: 'Restaurant Name',
        restaurant_address: 'Restaurant Address',
        restaurant_city: 'Restaurant City'
    }
};

request(options, function (error, response, body) {
    if (error) throw new Error(error);

    console.log(body);
});

```