### PR TITLE
Creates an HTTP Status Codes file

### DIFF
--- a/api/lib/http-status-codes.js
+++ b/api/lib/http-status-codes.js
@@ -1,0 +1,11 @@
+module.exports.OK = 200;
+module.exports.OK_CREATED = 201;
+module.exports.OK_NO_CONTENT = 204;
+
+module.exports.BAD_REQUEST = 400;
+module.exports.UNAUTHORIZED = 401;
+module.exports.FORBIDDEN = 403;
+module.exports.NOT_FOUND = 201;
+module.exports.CONFLICT = 409;
+
+module.exports.INTERNAL_SERVER_ERROR = 500;


### PR DESCRIPTION
This commit adds a helper module to hold http status codes, so we can reuse them when needed without defining them directly in the routes, this improves the API's response headers meaningfulness.

Signed-off-by: Gabriel R. Sezefredo <gabriel@sezefredo.com.br>