### PR TITLE
Adds an optional db parameter to DBClient

### DIFF
--- a/api/lib/DBClient.js
+++ b/api/lib/DBClient.js
@@ -3,14 +3,17 @@ const Cloudant = require('@cloudant/cloudant');
 const user = process.env.CLOUDANT_USER;
 const pw = process.env.CLOUDANT_PW;
 
-function DBClient() {
+function DBClient(db) {
+    if (db && typeof db !== 'string')
+        throw new Error(`DBClient db parameter must be of type string, ${typeof db} received.`);
+    this._db = db || null;
     this._client = Cloudant({account:user, password:pw});
 }
 
 DBClient.prototype.get = function(db, from, size) {
     return new Promise((res, rej) => {
         let database = this._client.db.use(db);
-        database.list({include_docs: true, skip: from, limit: size}, 
+        database.list({include_docs: true, skip: from, limit: size},
             function(err, body) {
                 if (err) return rej(err);
                 return res(body.rows);
@@ -18,7 +21,9 @@ DBClient.prototype.get = function(db, from, size) {
     });
 }
 
-DBClient.prototype.insert = function(doc, db) {
+DBClient.prototype.insert = function(doc, options) {
+    validateDB(this, options)
+    let db = this._db || options.db;
     return new Promise((res, rej) => {
         let database = this._client.db.use(db);
         database.insert(doc, (err, body, header) => {
@@ -30,3 +35,15 @@ DBClient.prototype.insert = function(doc, db) {
 }
 
 module.exports = DBClient;
+
+// Private functions
+
+function validateDB(instance, options) {
+    if (!instance._db){
+        if (!(options && options.db))
+            throw new Error('This client has no default databaset set, and one was not provided.');
+        if (typeof options.db !== 'string')
+            throw new Error(`Wrong type for parameter DB. ` +
+                `Received ${typeof options.db}, expected a string.`);
+    }
+}

--- a/api/v1/menus/create.js
+++ b/api/v1/menus/create.js
@@ -25,13 +25,13 @@ module.exports = (req, res, next) => {
 
     // Uploading to box and saving to db
     let fsClient = new FSClient();
-    let dbClient = new DBClient();
+    let dbClient = new DBClient('menus');
     fsClient.uploadMenu(req.file)
         .then(id => {
             menuEntry.file = `/files/${id}`
             return deleteFile(req.file.path);
         })
-        .then(() => dbClient.insert(menuEntry, 'menus'))
+        .then(() => dbClient.insert(menuEntry))
         .then(dbEntry => res.status(httpStatus.OK_CREATED).send(Object.assign(dbEntry, menuEntry)))
         .catch((err) => {
             return next(err) // Handled by the "menus" specific error handler, in menus/index.js


### PR DESCRIPTION
In our first implementation, DBClient had to receive a db parameter on all
of its methods. This commit adds an optional db parameter to its
constructor so if it's defined, a db parameter is not necessary in method
calls.

This commit also adapts the menu "insert" route to use this new
functionality.

A helper function "validateDB" was created in order to check if a db was
specified in a method call, it can be used in all methods of DBClient.

Signed-off-by: Gabriel R. Sezefredo <gabriel@sezefredo.com.br>